### PR TITLE
htmgo yml config

### DIFF
--- a/cli/htmgo/go.mod
+++ b/cli/htmgo/go.mod
@@ -11,3 +11,5 @@ require (
 	golang.org/x/sys v0.25.0
 	golang.org/x/tools v0.25.0
 )
+
+require github.com/bmatcuk/doublestar/v4 v4.7.1 // indirect

--- a/cli/htmgo/go.sum
+++ b/cli/htmgo/go.sum
@@ -1,3 +1,5 @@
+github.com/bmatcuk/doublestar/v4 v4.7.1 h1:fdDeAqgT47acgwd9bd9HxJRDmc9UAmPpc+2m0CXv75Q=
+github.com/bmatcuk/doublestar/v4 v4.7.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/dave/jennifer v1.7.1 h1:B4jJJDHelWcDhlRQxWeo0Npa/pYKBLrirAQoTN45txo=
 github.com/dave/jennifer v1.7.1/go.mod h1:nXbxhEmQfOZhWml3D1cDK5M1FLnMSozpbFN/m3RmGZc=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=

--- a/cli/htmgo/internal/dirutil/dir.go
+++ b/cli/htmgo/internal/dirutil/dir.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/maddalax/htmgo/cli/htmgo/tasks/process"
+	"github.com/maddalax/htmgo/framework/config"
 	"io"
 	"log/slog"
 	"os"
@@ -15,6 +16,10 @@ func HasFileFromRoot(file string) bool {
 	path := filepath.Join(cwd, file)
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+func GetConfig() *config.ProjectConfig {
+	return config.FromConfigFile(process.GetWorkingDir())
 }
 
 func CreateHtmgoDir() {

--- a/cli/htmgo/internal/dirutil/glob.go
+++ b/cli/htmgo/internal/dirutil/glob.go
@@ -3,8 +3,6 @@ package dirutil
 import (
 	"fmt"
 	"github.com/bmatcuk/doublestar/v4"
-	"io/fs"
-	"path/filepath"
 )
 
 func matchesAny(patterns []string, path string) bool {
@@ -30,21 +28,4 @@ func IsGlobMatch(path string, patterns []string, excludePatterns []string) bool 
 		return false
 	}
 	return matchesAny(patterns, path)
-}
-
-func GlobMatchDirs(root string, includePatterns, excludePatterns []string, cb func(string)) {
-	//directories := map[string]bool{}
-	// Walk through the directory recursively
-	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if matchesAny(excludePatterns, path) {
-			return fs.SkipDir
-		}
-		if matchesAny(includePatterns, path) {
-			cb(path)
-		}
-		return nil
-	})
 }

--- a/cli/htmgo/internal/dirutil/glob.go
+++ b/cli/htmgo/internal/dirutil/glob.go
@@ -1,0 +1,50 @@
+package dirutil
+
+import (
+	"fmt"
+	"github.com/bmatcuk/doublestar/v4"
+	"io/fs"
+	"path/filepath"
+)
+
+func matchesAny(patterns []string, path string) bool {
+	for _, pattern := range patterns {
+		matched, err := doublestar.Match(pattern, path)
+		if err != nil {
+			fmt.Printf("Error matching pattern: %v\n", err)
+			return false
+		}
+		if matched {
+			return true
+		}
+	}
+	return false
+}
+
+func IsGlobExclude(path string, excludePatterns []string) bool {
+	return matchesAny(excludePatterns, path)
+}
+
+func IsGlobMatch(path string, patterns []string, excludePatterns []string) bool {
+	if matchesAny(excludePatterns, path) {
+		return false
+	}
+	return matchesAny(patterns, path)
+}
+
+func GlobMatchDirs(root string, includePatterns, excludePatterns []string, cb func(string)) {
+	//directories := map[string]bool{}
+	// Walk through the directory recursively
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if matchesAny(excludePatterns, path) {
+			return fs.SkipDir
+		}
+		if matchesAny(includePatterns, path) {
+			cb(path)
+		}
+		return nil
+	})
+}

--- a/cli/htmgo/tasks/copyassets/bundle.go
+++ b/cli/htmgo/tasks/copyassets/bundle.go
@@ -92,7 +92,7 @@ func CopyAssets() {
 			})
 	}
 
-	if !dirutil.HasFileFromRoot("tailwind.config.js") {
+	if dirutil.GetConfig().Tailwind && !dirutil.HasFileFromRoot("tailwind.config.js") {
 		err = dirutil.CopyFile(
 			filepath.Join(assetCssDir, "tailwind.config.js"),
 			filepath.Join(process.GetWorkingDir(), "tailwind.config.js"),

--- a/cli/htmgo/tasks/css/css.go
+++ b/cli/htmgo/tasks/css/css.go
@@ -12,7 +12,7 @@ import (
 )
 
 func IsTailwindEnabled() bool {
-	return dirutil.HasFileFromRoot("tailwind.config.js")
+	return dirutil.GetConfig().Tailwind && dirutil.HasFileFromRoot("tailwind.config.js")
 }
 
 func Setup() bool {

--- a/framework/config/default.yml
+++ b/framework/config/default.yml
@@ -1,1 +1,0 @@
-tailwind: true

--- a/framework/config/default.yml
+++ b/framework/config/default.yml
@@ -1,0 +1,1 @@
+tailwind: true

--- a/framework/config/project.go
+++ b/framework/config/project.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"gopkg.in/yaml.v3"
+	"log/slog"
 	"os"
 	"path"
 )
@@ -45,9 +46,11 @@ func FromConfigFile(workingDir string) *ProjectConfig {
 			bytes, err := os.ReadFile(filePath)
 			if err == nil {
 				err = yaml.Unmarshal(bytes, cfg)
-				if err == nil {
-					return cfg.EnhanceWithDefaults()
+				if err != nil {
+					slog.Error("Error parsing config file", slog.String("file", filePath), slog.String("error", err.Error()))
+					os.Exit(1)
 				}
+				return cfg.EnhanceWithDefaults()
 			}
 		}
 	}

--- a/framework/config/project.go
+++ b/framework/config/project.go
@@ -19,7 +19,7 @@ func DefaultProjectConfig() *ProjectConfig {
 			"node_modules", ".git", ".idea", "assets/dist",
 		},
 		WatchFiles: []string{
-			"**/*.go", "**/*.html", "**/*.css", "**/*.js", "**/*.json", "**/*.yaml", "**/*.yml",
+			"**/*.go", "**/*.html", "**/*.css", "**/*.js", "**/*.json", "**/*.yaml", "**/*.yml", "**/*.md",
 		},
 	}
 }

--- a/framework/config/project.go
+++ b/framework/config/project.go
@@ -1,0 +1,55 @@
+package config
+
+import (
+	"gopkg.in/yaml.v3"
+	"os"
+	"path"
+)
+
+type ProjectConfig struct {
+	Tailwind    bool     `yaml:"tailwind"`
+	WatchIgnore []string `yaml:"watch_ignore"`
+	WatchFiles  []string `yaml:"watch_files"`
+}
+
+func DefaultProjectConfig() *ProjectConfig {
+	return &ProjectConfig{
+		Tailwind: true,
+		WatchIgnore: []string{
+			"node_modules", ".git", ".idea", "assets/dist",
+		},
+		WatchFiles: []string{
+			"**/*.go", "**/*.html", "**/*.css", "**/*.js", "**/*.json", "**/*.yaml", "**/*.yml",
+		},
+	}
+}
+
+func (cfg *ProjectConfig) EnhanceWithDefaults() *ProjectConfig {
+	defaultCfg := DefaultProjectConfig()
+	if len(cfg.WatchFiles) == 0 {
+		cfg.WatchFiles = defaultCfg.WatchFiles
+	}
+	if len(cfg.WatchIgnore) == 0 {
+		cfg.WatchIgnore = defaultCfg.WatchIgnore
+	}
+	return cfg
+}
+
+func FromConfigFile(workingDir string) *ProjectConfig {
+	defaultCfg := DefaultProjectConfig()
+	names := []string{"htmgo.yaml", "htmgo.yml", "_htmgo.yaml", "_htmgo.yml"}
+	for _, name := range names {
+		filePath := path.Join(workingDir, name)
+		if _, err := os.Stat(filePath); err == nil {
+			cfg := &ProjectConfig{}
+			bytes, err := os.ReadFile(filePath)
+			if err == nil {
+				err = yaml.Unmarshal(bytes, cfg)
+				if err == nil {
+					return cfg.EnhanceWithDefaults()
+				}
+			}
+		}
+	}
+	return defaultCfg
+}

--- a/framework/config/project_test.go
+++ b/framework/config/project_test.go
@@ -16,7 +16,7 @@ func TestDefaultProjectConfig(t *testing.T) {
 
 func TestNoConfigFileUsesDefault(t *testing.T) {
 	t.Parallel()
-	cfg := FromConfigFile("testdata")
+	cfg := FromConfigFile("testdata2")
 	assert.Equal(t, true, cfg.Tailwind)
 	assert.Equal(t, 4, len(cfg.WatchIgnore))
 	assert.Equal(t, 8, len(cfg.WatchFiles))

--- a/framework/config/project_test.go
+++ b/framework/config/project_test.go
@@ -1,0 +1,31 @@
+package config
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestDefaultProjectConfig(t *testing.T) {
+	cfg := DefaultProjectConfig()
+	assert.Equal(t, true, cfg.Tailwind)
+	assert.Equal(t, 4, len(cfg.WatchIgnore))
+	assert.Equal(t, 8, len(cfg.WatchFiles))
+}
+
+func TestNoConfigFileUsesDefault(t *testing.T) {
+	cfg := FromConfigFile("testdata")
+	assert.Equal(t, true, cfg.Tailwind)
+	assert.Equal(t, 4, len(cfg.WatchIgnore))
+	assert.Equal(t, 8, len(cfg.WatchFiles))
+}
+
+func TestPartialConfigMerges(t *testing.T) {
+	os.Mkdir("testdata", 0755)
+	defer os.RemoveAll("testdata")
+	os.WriteFile("testdata/htmgo.yaml", []byte("tailwind: false"), 0644)
+	cfg := FromConfigFile("testdata")
+	assert.Equal(t, false, cfg.Tailwind)
+	assert.Equal(t, 4, len(cfg.WatchIgnore))
+	assert.Equal(t, 8, len(cfg.WatchFiles))
+}

--- a/framework/config/project_test.go
+++ b/framework/config/project_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestDefaultProjectConfig(t *testing.T) {
+	t.Parallel()
 	cfg := DefaultProjectConfig()
 	assert.Equal(t, true, cfg.Tailwind)
 	assert.Equal(t, 4, len(cfg.WatchIgnore))
@@ -14,6 +15,7 @@ func TestDefaultProjectConfig(t *testing.T) {
 }
 
 func TestNoConfigFileUsesDefault(t *testing.T) {
+	t.Parallel()
 	cfg := FromConfigFile("testdata")
 	assert.Equal(t, true, cfg.Tailwind)
 	assert.Equal(t, 4, len(cfg.WatchIgnore))
@@ -21,9 +23,21 @@ func TestNoConfigFileUsesDefault(t *testing.T) {
 }
 
 func TestPartialConfigMerges(t *testing.T) {
+	t.Parallel()
 	os.Mkdir("testdata", 0755)
 	defer os.RemoveAll("testdata")
 	os.WriteFile("testdata/htmgo.yaml", []byte("tailwind: false"), 0644)
+	cfg := FromConfigFile("testdata")
+	assert.Equal(t, false, cfg.Tailwind)
+	assert.Equal(t, 4, len(cfg.WatchIgnore))
+	assert.Equal(t, 8, len(cfg.WatchFiles))
+}
+
+func TestShouldNotSetTailwindTrue(t *testing.T) {
+	t.Parallel()
+	os.Mkdir("testdata1", 0755)
+	defer os.RemoveAll("testdata1")
+	os.WriteFile("testdata1/htmgo.yaml", []byte("someValue: false"), 0644)
 	cfg := FromConfigFile("testdata")
 	assert.Equal(t, false, cfg.Tailwind)
 	assert.Equal(t, 4, len(cfg.WatchIgnore))

--- a/htmgo-site/htmgo.yml
+++ b/htmgo-site/htmgo.yml
@@ -1,0 +1,5 @@
+tailwind: true
+# which directories to ignore when watching for changes, supports glob patterns
+watch_ignore: [".git", "node_modules", "dist/*"]
+# files to watch for changes that are not included by default, supports glob patterns
+watch_files: ["**/*.go", "**/*.css"]

--- a/htmgo-site/htmgo.yml
+++ b/htmgo-site/htmgo.yml
@@ -1,5 +1,10 @@
+# htmgo configuration
+
+# if tailwindcss is enabled, htmgo will automatically compile your tailwind and output it to assets/dist
 tailwind: true
-# which directories to ignore when watching for changes, supports glob patterns
+
+# which directories to ignore when watching for changes, supports glob patterns through https://github.com/bmatcuk/doublestar
 watch_ignore: [".git", "node_modules", "dist/*"]
-# files to watch for changes that are not included by default, supports glob patterns
-watch_files: ["**/*.go", "**/*.css"]
+
+# files to watch for changes, supports glob patterns through https://github.com/bmatcuk/doublestar
+watch_files: ["**/*.go", "**/*.css", "**/*.md"]

--- a/htmgo-site/pages/base/root.go
+++ b/htmgo-site/pages/base/root.go
@@ -45,7 +45,8 @@ func PageWithNav(ctx *h.RequestContext, children ...h.Ren) *h.Element {
 	return RootPage(ctx,
 		h.Fragment(
 			partials.NavBar(ctx, partials.NavBarProps{
-				Expanded: false,
+				Expanded:       false,
+				ShowPreRelease: true,
 			}),
 			h.Div(
 				children...,

--- a/templates/starter/htmgo.yml
+++ b/templates/starter/htmgo.yml
@@ -1,0 +1,10 @@
+# htmgo configuration
+
+# if tailwindcss is enabled, htmgo will automatically compile your tailwind and output it to assets/dist
+tailwind: true
+
+# which directories to ignore when watching for changes, supports glob patterns through https://github.com/bmatcuk/doublestar
+watch_ignore: [".git", "node_modules", "dist/*"]
+
+# files to watch for changes, supports glob patterns through https://github.com/bmatcuk/doublestar
+watch_files: ["**/*.go", "**/*.css", "**/*.md"]


### PR DESCRIPTION
Adds support for configuring htmgo with a yml file, the current version will include

tailwind: true/false (if tailwind is enabled or not)
watch_ignore: directories to ignore for the file watcher
watch_files: files or directories to watch
