### PR TITLE
Update app.go

### DIFF
--- a/framework/h/app.go
+++ b/framework/h/app.go
@@ -182,7 +182,7 @@ func (app *App) start() {
 	}
 
 	port := ":3000"
-	slog.Info(fmt.Sprintf("Server started on port %s", port))
+	slog.Info(fmt.Sprintf("Server started at localhost:%s", port))
 	err := http.ListenAndServe(port, app.Router)
 
 	if err != nil {


### PR DESCRIPTION
Just a small little change to the structured log output when starting the chi server. It's nice to output the host and port like 'localhost:3000' . This let's you click on it directly from your ide or terminal and just open it up in a browser. In MacOS for example i just command + click on that log message and am able to go right to localhost:3000 in chrome. Not able to do this with the current ':3000' message. 