### PR TITLE
Update slog output for server start

### DIFF
--- a/framework/h/app.go
+++ b/framework/h/app.go
@@ -213,7 +213,7 @@ func (app *App) start() {
 	}
 
 	port := ":3000"
-	slog.Info(fmt.Sprintf("Server started at localhost:%s", port))
+	slog.Info(fmt.Sprintf("Server started at localhost%s", port))
 	err := http.ListenAndServe(port, app.Router)
 
 	if err != nil {


### PR DESCRIPTION
Previously when i submitted a PR for this I failed to notice that the `port` variable was already defined with a colon. That lead to the output looking like `localhost::3000` instead of the intended `localhost:3000` . Removed the colon in the slog output so now it will read `localhost:3000`. Sorry!

