### PR TITLE
Use filename instead of absolute path when filtering to replacing old template name with new one 

### DIFF
--- a/cli/htmgo/tasks/util/file.go
+++ b/cli/htmgo/tasks/util/file.go
@@ -19,7 +19,7 @@ func ReplaceTextInFile(file string, text string, replacement string) error {
 
 func ReplaceTextInDirRecursive(dir string, text string, replacement string, filter func(file string) bool) error {
 	return filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
-		if filter(path) {
+		if filter(filepath.Base(path)) {
 			_ = ReplaceTextInFile(path, text, replacement)
 		}
 		return nil


### PR DESCRIPTION
When generating the default template with `htmgo template`, the prompted template name is replaced according to these lines:
```go
_ = util.ReplaceTextInFile(filepath.Join(newDir, "go.mod"),
	fmt.Sprintf("module %s", templateName),
	fmt.Sprintf("module %s", newModuleName))

_ = util.ReplaceTextInDirRecursive(newDir, templateName, newModuleName, func(file string) bool {
	return strings.HasSuffix(file, ".go") || strings.HasPrefix(file, "Dockerfile")
})
```

This correctly replaces `starter-template` everywhere except in the Dockerfile. 
The underlying `ReplaceTextInDirRecursive` filters by `path` as in the _**absolute path**_ of the file.

This works correctly for `strings.HasSuffix(file, ".go")` since file extensions are suffixes for filenames and paths anyway but it doesn't work for `strings.HasPrefix(file, "Dockerfile")` 

I suggest instead of `filter(path)` we use `filter(filepath.Base(path))` which correctly passes the filename (the `base` of each path) and returns `true` for strings.HasPrefix(file, "Dockerfile") when matched against any `Dockerfile`.
