### PR TITLE
gen code for assets

### DIFF
--- a/framework/config/project.go
+++ b/framework/config/project.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/maddalax/htmgo/cli/htmgo/tasks/process"
 	"gopkg.in/yaml.v3"
 	"log/slog"
 	"os"
@@ -14,6 +15,7 @@ type ProjectConfig struct {
 	WatchFiles                    []string `yaml:"watch_files"`
 	AutomaticPageRoutingIgnore    []string `yaml:"automatic_page_routing_ignore"`
 	AutomaticPartialRoutingIgnore []string `yaml:"automatic_partial_routing_ignore"`
+	PublicAssetPath               string   `yaml:"public_asset_path"`
 }
 
 func DefaultProjectConfig() *ProjectConfig {
@@ -25,6 +27,7 @@ func DefaultProjectConfig() *ProjectConfig {
 		WatchFiles: []string{
 			"**/*.go", "**/*.html", "**/*.css", "**/*.js", "**/*.json", "**/*.yaml", "**/*.yml", "**/*.md",
 		},
+		PublicAssetPath: "/public",
 	}
 }
 
@@ -57,7 +60,17 @@ func (cfg *ProjectConfig) Enhance() *ProjectConfig {
 		}
 	}
 
+	if cfg.PublicAssetPath == "" {
+		cfg.PublicAssetPath = "/public"
+	}
+
 	return cfg
+}
+
+func Get() *ProjectConfig {
+	cwd := process.GetWorkingDir()
+	config := FromConfigFile(cwd)
+	return config
 }
 
 func FromConfigFile(workingDir string) *ProjectConfig {

--- a/framework/config/project.go
+++ b/framework/config/project.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"github.com/maddalax/htmgo/cli/htmgo/tasks/process"
 	"gopkg.in/yaml.v3"
 	"log/slog"
 	"os"
@@ -68,7 +67,10 @@ func (cfg *ProjectConfig) Enhance() *ProjectConfig {
 }
 
 func Get() *ProjectConfig {
-	cwd := process.GetWorkingDir()
+	cwd, err := os.Getwd()
+	if err != nil {
+		return DefaultProjectConfig()
+	}
 	config := FromConfigFile(cwd)
 	return config
 }

--- a/framework/config/project_test.go
+++ b/framework/config/project_test.go
@@ -73,6 +73,15 @@ func TestShouldPrefixAutomaticPartialRoutingIgnore_1(t *testing.T) {
 	assert.Equal(t, []string{"partials/somefile/*"}, cfg.AutomaticPartialRoutingIgnore)
 }
 
+func TestPublicAssetPath(t *testing.T) {
+	t.Parallel()
+	cfg := DefaultProjectConfig()
+	assert.Equal(t, "/public", cfg.PublicAssetPath)
+
+	cfg.PublicAssetPath = "/assets"
+	assert.Equal(t, "/assets", cfg.PublicAssetPath)
+}
+
 func writeConfigFile(t *testing.T, content string) string {
 	temp := os.TempDir()
 	os.Mkdir(temp, 0755)

--- a/framework/config/project_test.go
+++ b/framework/config/project_test.go
@@ -82,6 +82,12 @@ func TestPublicAssetPath(t *testing.T) {
 	assert.Equal(t, "/assets", cfg.PublicAssetPath)
 }
 
+func TestConfigGet(t *testing.T) {
+	t.Parallel()
+	cfg := Get()
+	assert.Equal(t, "/public", cfg.PublicAssetPath)
+}
+
 func writeConfigFile(t *testing.T, content string) string {
 	temp := os.TempDir()
 	os.Mkdir(temp, 0755)

--- a/htmgo-site/pages/base/root.go
+++ b/htmgo-site/pages/base/root.go
@@ -3,6 +3,7 @@ package base
 import (
 	"github.com/google/uuid"
 	"github.com/maddalax/htmgo/framework/h"
+	"htmgo-site/__htmgo/assets"
 	"htmgo-site/partials"
 )
 
@@ -43,8 +44,8 @@ func ConfigurableRootPage(ctx *h.RequestContext, props RootPageProps) *h.Page {
 				h.Title(
 					h.Text(title),
 				),
-				h.Link("/public/favicon.ico", "icon"),
-				h.Link("/public/apple-touch-icon.png", "apple-touch-icon"),
+				h.Link(assets.FaviconIco, "icon"),
+				h.Link(assets.AppleTouchIconPng, "apple-touch-icon"),
 				h.Meta("charset", "utf-8"),
 				h.Meta("author", "htmgo"),
 				h.Meta("description", description),
@@ -53,8 +54,8 @@ func ConfigurableRootPage(ctx *h.RequestContext, props RootPageProps) *h.Page {
 				h.Link("canonical", canonical),
 				h.Link("https://cdn.jsdelivr.net/npm/@docsearch/css@3", "stylesheet"),
 				h.Meta("og:description", description),
-				h.LinkWithVersion("/public/main.css", "stylesheet", Version),
-				h.ScriptWithVersion("/public/htmgo.js", Version),
+				h.LinkWithVersion(assets.MainCss, "stylesheet", Version),
+				h.ScriptWithVersion(assets.HtmgoJs, Version),
 				h.Style(`
 				html {
 					scroll-behavior: smooth;

--- a/htmgo-site/pages/docs/htmx-extensions/overview.go
+++ b/htmgo-site/pages/docs/htmx-extensions/overview.go
@@ -61,20 +61,3 @@ h.JoinExtensions(
     h.HxExtension("my-extension"),
 )
 `
-
-const htmxExtensions = `
-h.HxOnLoad
-h.HxOnAfterSwap
-h.OnClick
-h.OnSubmit
-h.HxBeforeSseMessage
-h.HxAfterSseMessage
-h.OnClick
-h.OnSubmit
-h.HxOnSseError
-h.HxOnSseClose
-h.HxOnSseConnecting
-h.HxOnSseOpen
-h.HxAfterRequest
-h.HxOnMutationError
-`

--- a/templates/starter/htmgo.yml
+++ b/templates/starter/htmgo.yml
@@ -16,3 +16,6 @@ automatic_page_routing_ignore: ["root.go"]
 # files or directories to ignore when automatically registering routes for partials
 # supports glob patterns through https://github.com/bmatcuk/doublestar
 automatic_partial_routing_ignore: []
+
+# url path of where the public assets are located
+public_asset_path: "/public"

--- a/templates/starter/main.go
+++ b/templates/starter/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"github.com/maddalax/htmgo/framework/config"
 	"github.com/maddalax/htmgo/framework/h"
 	"github.com/maddalax/htmgo/framework/service"
 	"io/fs"
@@ -10,6 +12,7 @@ import (
 
 func main() {
 	locator := service.NewLocator()
+	cfg := config.Get()
 
 	h.Start(h.AppOpts{
 		ServiceLocator: locator,
@@ -23,7 +26,10 @@ func main() {
 
 			http.FileServerFS(sub)
 
-			app.Router.Handle("/public/*", http.StripPrefix("/public", http.FileServerFS(sub)))
+			// change this in htmgo.yml (public_asset_path)
+			app.Router.Handle(fmt.Sprintf("%s/*", cfg.PublicAssetPath),
+				http.StripPrefix(cfg.PublicAssetPath, http.FileServerFS(sub)))
+
 			__htmgo.Register(app.Router)
 		},
 	})

--- a/templates/starter/pages/root.go
+++ b/templates/starter/pages/root.go
@@ -2,6 +2,7 @@ package pages
 
 import (
 	"github.com/maddalax/htmgo/framework/h"
+	"starter-template/__htmgo/assets"
 )
 
 func RootPage(children ...h.Ren) *h.Page {
@@ -20,8 +21,8 @@ func RootPage(children ...h.Ren) *h.Page {
 					h.Text(title),
 				),
 				h.Meta("viewport", "width=device-width, initial-scale=1"),
-				h.Link("/public/favicon.ico", "icon"),
-				h.Link("/public/apple-touch-icon.png", "apple-touch-icon"),
+				h.Link(assets.FaviconIco, "icon"),
+				h.Link(assets.AppleTouchIconPng, "apple-touch-icon"),
 				h.Meta("title", title),
 				h.Meta("charset", "utf-8"),
 				h.Meta("author", author),
@@ -30,8 +31,8 @@ func RootPage(children ...h.Ren) *h.Page {
 				h.Meta("og:url", url),
 				h.Link("canonical", url),
 				h.Meta("og:description", description),
-				h.Link("/public/main.css", "stylesheet"),
-				h.Script("/public/htmgo.js"),
+				h.Link(assets.MainCss, "stylesheet"),
+				h.Script(assets.HtmgoJs),
 			),
 			h.Body(
 				h.Div(


### PR DESCRIPTION
https://github.com/maddalax/htmgo/issues/54

This allows you to reference any assets you have in the /assets folder in go code, the codegen will now generate a file like this whenever htmgo starts

```
package assets

const AppleTouchIconPng = "/public/apple-touch-icon.png"
const FaviconIco = "/public/favicon.ico"
const HtmgoJs = "/public/htmgo.js"
const Icon192MaskablePng = "/public/icon-192-maskable.png"
const Icon192Png = "/public/icon-192.png"
const Icon512MaskablePng = "/public/icon-512-maskable.png"
const Icon512Png = "/public/icon-512.png"
const MainCss = "/public/main.css"
```

The path can be configured by editing 'public_asset_path' in htmgo.yml